### PR TITLE
MBS-6151: Make adding new slides consistent to grid

### DIFF
--- a/type/carousel/classes/content_type.php
+++ b/type/carousel/classes/content_type.php
@@ -171,7 +171,7 @@ class content_type extends \mod_unilabel\content_type {
             $prefix.'add_more_slides_btn',
             $defaultrepeatcount, // Each time we add 3 elements.
             get_string('addmoreslides', 'unilabeltype_carousel'),
-            true
+            false
         );
     }
 


### PR DESCRIPTION
In carousel you need to expand the last slide entry to add new slides. This PR makes the button for adding new slides always visible (like in grid).