### PR TITLE
MBS-6161: Make indicators and controls always visible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,7 @@
 .unilabel .carousel .carousel-control-prev,
 .unilabel .carousel .carousel-control-next {
     z-index: 998;
+    mix-blend-mode: difference;
 }
 
 /* Nice overlay effect which can be used in subplugins */

--- a/type/carousel/styles.css
+++ b/type/carousel/styles.css
@@ -1,4 +1,5 @@
 .unilabel-content ul.carousel-indicators,
 .course-content li.section .unilabel-content ul.carousel-indicators {
     list-style: none;
+    mix-blend-mode: difference;
 }


### PR DESCRIPTION
Indicators and controls are not visible on white / light background:
![grafik](https://user-images.githubusercontent.com/26581385/154331079-14f123d2-2487-479f-87a4-baa2558f317c.png)
This PR uses mix-blend-mode: difference for both:
![grafik](https://user-images.githubusercontent.com/26581385/154331240-4d5b46eb-ffbb-4f2a-a86b-a294f6e4eff3.png)
