### PR TITLE
MBS-6386: Fix redirect in view.php

### DIFF
--- a/view.php
+++ b/view.php
@@ -30,7 +30,7 @@ $l = optional_param('l', 0, PARAM_INT);     // The unilabel ID.
 
 if ($id) {
     $PAGE->set_url('/mod/unilabel/index.php', ['id' => $id]);
-    if (!$cm = get_coursemodule_from_id('unilabel', $id)) {
+    if (!$cm = get_coursemodule_from_id('unilabel', $id, 0, true)) {
         throw new \moodle_exception('invalidcoursemodule');
     }
 
@@ -49,11 +49,11 @@ if ($id) {
     if (!$course = $DB->get_record('course', ['id' => $unilabel->course])) {
         throw new \moodle_exception('coursemisconf');
     }
-    if (!$cm = get_coursemodule_from_instance('unilabel', $unilabel->id, $course->id)) {
+    if (!$cm = get_coursemodule_from_instance('unilabel', $unilabel->id, $course->id, true)) {
         throw new \moodle_exception('invalidcoursemodule');
     }
 }
 
 require_login($course, true, $cm);
 
-redirect("$CFG->wwwroot/course/view.php?id=$course->id");
+redirect("$CFG->wwwroot/course/view.php?id=$course->id&section=$cm->sectionnum#module-$cm->id");


### PR DESCRIPTION
view.php does only redirect to the main course page but not to the place, the unilabel actually is located.
This PR changes the behavior to redirect to the section of the unilabel and adds the #module-... anchor to avoid scrolling.