### PR TITLE
MBS-6568: Adding collapsed class to template

### DIFF
--- a/type/accordion/templates/accordion.mustache
+++ b/type/accordion/templates/accordion.mustache
@@ -54,7 +54,7 @@ along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 {{#segments}}
     <div class="card" id="accordion-{{cmid}}-{{id}}">
         <div class="card-header" id="accordion-heading-{{cmid}}-{{id}}">
-            <button id="unilabel-button-{{cmid}}-{{id}}" class="btn btn-link btn-block" type="button" data-toggle="collapse" data-target="#accordion-segment-{{cmid}}-{{id}}" aria-expanded="false" aria-controls="accordion-segment-{{cmid}}-{{id}}">
+            <button id="unilabel-button-{{cmid}}-{{id}}" class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#accordion-segment-{{cmid}}-{{id}}" aria-expanded="false" aria-controls="accordion-segment-{{cmid}}-{{id}}">
                 {{{ heading }}}
             </button>
         </div>


### PR DESCRIPTION
When the page is initialized, the individual sections are collapsed. But a corresponding class does not exist yet. Only after folding out and folding in again this class is available. To maintain consistency, this class is already added during init. This also enables CSS actions that react differently to the individual states.