### PR TITLE
MBS-6647: Compatibility with moodle 4.0 version of format_tiles

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -150,6 +150,8 @@ function unilabel_cm_info_view(\cm_info $cm) {
     }
 
     $cm->set_content($renderer->render_from_template('mod_unilabel/content', $content));
+
+    $cm->set_custom_cmlist_item(true);
 }
 
 /**


### PR DESCRIPTION
When using latest version of format_tiles with sub-tiles, unilabel is not shown as a label. This PR solves this (similiar to https://github.com/mebis-lp/mod_learningmap/pull/30 ).