### PR TITLE
Feature/advancedactivitychooser moodle 401 stable

### DIFF
--- a/type/grid/classes/content_type.php
+++ b/type/grid/classes/content_type.php
@@ -156,7 +156,7 @@ class content_type extends \mod_unilabel\content_type {
             'static',
             $prefix.'activityname',
             get_string('activityname', 'unilabeltype_grid'),
-            ['size' => 50]
+            get_string('noactivity', 'unilabeltype_grid'),
         );
 
         $repeatarray[] = $mform->createElement(
@@ -203,6 +203,7 @@ class content_type extends \mod_unilabel\content_type {
 
         // Element to show the name of an activity.
         $repeatedoptions[$prefix.'activityname']['type'] = PARAM_TEXT;
+        $repeatedoptions[$prefix.'activityname']['helpbutton'] = ['activityname', 'unilabeltype_grid'];
 
         $defaultrepeatcount = 4; // The default count for tiles.
         $repeatcount = count($this->tiles);
@@ -518,7 +519,6 @@ class content_type extends \mod_unilabel\content_type {
             $tilerecord->gridid = $unilabeltyperecord->id;
             $tilerecord->title = $title;
             $tilerecord->url = $formdata->{$prefix.'url'}[$i];
-            // bei speichern nicht notwendig $tilerecord->url = $formdata->{$prefix.'activityname'}[$i];
 
             $tilerecord->content = ''; // Dummy content.
             $tilerecord->id = $DB->insert_record('unilabeltype_grid_tile', $tilerecord);

--- a/type/grid/classes/content_type.php
+++ b/type/grid/classes/content_type.php
@@ -159,15 +159,6 @@ class content_type extends \mod_unilabel\content_type {
             ['size' => 50]
         );
 
-        // Element to be able to hide or show the activityname.
-        /*
-         $repeatarray[] = $mform->createElement(
-            'hidden',
-            $prefix . 'activityfound',
-            'false',
-        );
-        */
-
         $repeatarray[] = $mform->createElement(
                                 'static',
                                 $prefix.'activitypickerbutton',
@@ -212,8 +203,6 @@ class content_type extends \mod_unilabel\content_type {
 
         // Element to show the name of an activity.
         $repeatedoptions[$prefix.'activityname']['type'] = PARAM_TEXT;
-        //$repeatedoptions[$prefix.'activityname']['hideif'] = [$prefix.'activityfound', 'eq', 'false'];
-        //$repeatedoptions[$prefix.'activityname']['disabledif'] = [$prefix.'activityfound', 'eq', 'true'];
 
         $defaultrepeatcount = 4; // The default count for tiles.
         $repeatcount = count($this->tiles);
@@ -347,14 +336,8 @@ class content_type extends \mod_unilabel\content_type {
             // Check, if url is a link to an existing activity array.
             $elementname = $prefix . 'activityname[' . $index . ']';
             $data[$elementname] = get_string('noactivity', 'unilabeltype_grid');
-            //$elementname = $prefix . 'activityfound[' . $index . ']';
-            //$data[$elementname] = 'false';
             foreach ($activitys as $key => $activity) {
                 if ($tile->url == $key) {
-                    // To be able to use hideif
-                    //$elementname = $prefix . 'activityfound[' . $index . ']';
-                    //$data[$elementname] = 'true';
-
                     $elementname = $prefix . 'activityname[' . $index . ']';
                     $data[$elementname] = $activity;
                     break;

--- a/type/grid/lang/en/unilabeltype_grid.php
+++ b/type/grid/lang/en/unilabeltype_grid.php
@@ -26,6 +26,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $string['activityname'] = 'Name of the activity';
+$string['activityname_help'] = 'If the URL belongs to an activity in this course then the activity name will be shown below the URL.';
 $string['addmoretiles'] = 'Add more tiles';
 $string['autoheight'] = 'Auto height';
 $string['background'] = 'Background';
@@ -46,7 +47,7 @@ $string['image_mobile_help'] = 'Mobile images will be shown on screens smaller t
 $string['indicatorisstealth'] = '(stealth - available but hidden)';
 $string['indicatorvisible'] = '(visible)';
 $string['indicatorhidden'] = '(hidden - not accessable)';
-$string['noactivity'] = '...';
+$string['noactivity'] = '';
 $string['nocontent'] = 'No content';
 $string['pluginname'] = 'Grid';
 $string['pluginname_help'] = 'This plugin type creates a grid consisting of pictures. A click on the image opens a modal dialog field or brings the user to a defined url.';

--- a/type/grid/lang/en/unilabeltype_grid.php
+++ b/type/grid/lang/en/unilabeltype_grid.php
@@ -25,6 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
+$string['activityname'] = 'Name of the activity';
 $string['addmoretiles'] = 'Add more tiles';
 $string['autoheight'] = 'Auto height';
 $string['background'] = 'Background';
@@ -42,6 +43,10 @@ $string['height_help'] = 'If your pictures are of a different size, use the fixe
 $string['image'] = 'Image';
 $string['image_mobile'] = 'Image mobile';
 $string['image_mobile_help'] = 'Mobile images will be shown on screens smaller than 768px. If you do not define a mobile image the general image is shown on all screens.';
+$string['indicatorisstealth'] = '(stealth - available but hidden)';
+$string['indicatorvisible'] = '(visible)';
+$string['indicatorhidden'] = '(hidden - not accessable)';
+$string['noactivity'] = '...';
 $string['nocontent'] = 'No content';
 $string['pluginname'] = 'Grid';
 $string['pluginname_help'] = 'This plugin type creates a grid consisting of pictures. A click on the image opens a modal dialog field or brings the user to a defined url.';


### PR DESCRIPTION
First attempt to add the name of an activity if URL belongs to an activity in the course.

![grafik](https://github.com/grabs/moodle-mod_unilabel/assets/31856043/e97647a6-78bd-4c47-a519-cec71f315ca5)

(The update of the name when selecting an activity is still missing but also without this feature showing the name of an activity might be a good feature.)
