### PR TITLE
MBS-8732: Change misleading cursor

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,11 @@
     cursor: move;
     display: inline;
 }
+
+#page-mod-unilabel-edit_content form fieldset.draggable {
+    cursor: inherit;
+}
+
 #page-mod-unilabel-edit_content form fieldset.draggable.dragging {
     opacity: 0;
 }


### PR DESCRIPTION
New drag-and-drop function shows a misleading cursor: Due to the use of the class "draggable" there is always a move cursor when hovering a tile / segment / ... in the edit form, not only when hovering the drag handle.

This PR fixes this.