### PR TITLE
MBS-10379: Add foreign keys to all unilabel type plugins

### DIFF
--- a/type/accordion/db/install.xml
+++ b/type/accordion/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/accordion/db" VERSION="20220718" COMMENT="XMLDB file for Moodle mod/unilabel/type/accordion"
+<XMLDB PATH="mod/unilabel/type/accordion/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/accordion"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -13,6 +13,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="unilabeltype_accordion_seg" COMMENT="Default comment for the table, please edit me">
@@ -26,6 +27,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="accordionid" TYPE="foreign" FIELDS="accordionid" REFTABLE="unilabeltype_accordion" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/accordion/db/upgrade.php
+++ b/type/accordion/db/upgrade.php
@@ -73,5 +73,17 @@ function xmldb_unilabeltype_accordion_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025030800, 'unilabeltype', 'accordion');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_accordion');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        $table = new xmldb_table('unilabeltype_accordion_seg');
+        $key = new xmldb_key('accordionid', XMLDB_KEY_FOREIGN, ['accordionid'], 'unilabeltype_accordion', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'accordion');
+    }
+
     return true;
 }

--- a/type/accordion/version.php
+++ b/type/accordion/version.php
@@ -24,5 +24,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_accordion';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/carousel/db/install.xml
+++ b/type/carousel/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/carousel/db" VERSION="20180729" COMMENT="XMLDB file for Moodle mod/unilabel/type/carousel"
+<XMLDB PATH="mod/unilabel/type/carousel/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/carousel"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -18,6 +18,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="unilabeltype_carousel_slide" COMMENT="Default comment for the table, please edit me">
@@ -33,6 +34,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="carouselid" TYPE="foreign" FIELDS="carouselid" REFTABLE="unilabeltype_carousel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/carousel/db/upgrade.php
+++ b/type/carousel/db/upgrade.php
@@ -113,5 +113,17 @@ function xmldb_unilabeltype_carousel_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025030800, 'unilabeltype', 'carousel');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_carousel');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        $table = new xmldb_table('unilabeltype_carousel_slide');
+        $key = new xmldb_key('carouselid', XMLDB_KEY_FOREIGN, ['carouselid'], 'unilabeltype_carousel', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'carousel');
+    }
+
     return true;
 }

--- a/type/carousel/version.php
+++ b/type/carousel/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_carousel';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/collapsedtext/db/install.xml
+++ b/type/collapsedtext/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/collapsedtext/db" VERSION="20180729" COMMENT="XMLDB file for Moodle mod/unilabel/type/collapsedtext"
+<XMLDB PATH="mod/unilabel/type/collapsedtext/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/collapsedtext"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -14,6 +14,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/collapsedtext/db/upgrade.php
+++ b/type/collapsedtext/db/upgrade.php
@@ -71,5 +71,14 @@ function xmldb_unilabeltype_collapsedtext_upgrade($oldversion) {
         // Collapsedtext savepoint reached.
         upgrade_plugin_savepoint(true, 2025042202, 'unilabeltype', 'collapsedtext');
     }
+
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_collapsedtext');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'collapsedtext');
+    }
+
     return true;
 }

--- a/type/collapsedtext/version.php
+++ b/type/collapsedtext/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_collapsedtext';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/courseteaser/db/install.xml
+++ b/type/courseteaser/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/courseteaser/db" VERSION="20180729" COMMENT="XMLDB file for Moodle mod/unilabel/type/courseteaser"
+<XMLDB PATH="mod/unilabel/type/courseteaser/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/courseteaser"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -18,6 +18,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/courseteaser/db/upgrade.php
+++ b/type/courseteaser/db/upgrade.php
@@ -96,5 +96,13 @@ function xmldb_unilabeltype_courseteaser_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020022900, 'unilabeltype', 'courseteaser');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_courseteaser');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'courseteaser');
+    }
+
     return true;
 }

--- a/type/courseteaser/version.php
+++ b/type/courseteaser/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_courseteaser';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/grid/db/install.xml
+++ b/type/grid/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/grid/db" VERSION="20231215" COMMENT="XMLDB file for Moodle mod/unilabel/type/grid"
+<XMLDB PATH="mod/unilabel/type/grid/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/grid"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -17,6 +17,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="unilabeltype_grid_tile" COMMENT="Default comment for the table, please edit me">
@@ -33,6 +34,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="gridid" TYPE="foreign" FIELDS="gridid" REFTABLE="unilabeltype_grid" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/grid/db/upgrade.php
+++ b/type/grid/db/upgrade.php
@@ -114,5 +114,17 @@ function xmldb_unilabeltype_grid_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025030800, 'unilabeltype', 'grid');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_grid');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        $table = new xmldb_table('unilabeltype_grid_tile');
+        $key = new xmldb_key('gridid', XMLDB_KEY_FOREIGN, ['gridid'], 'unilabeltype_grid', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'grid');
+    }
+
     return true;
 }

--- a/type/grid/version.php
+++ b/type/grid/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_grid';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/imageboard/db/install.xml
+++ b/type/imageboard/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/imageboard/db" VERSION="20231029" COMMENT="XMLDB file for Moodle mod/unilabel/type/imageboard"
+<XMLDB PATH="mod/unilabel/type/imageboard/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/imageboard"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,6 +19,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
     <TABLE NAME="unilabeltype_imageboard_img" COMMENT="Default comment for the table, please edit me">
@@ -39,6 +40,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="imageboardid" TYPE="foreign" FIELDS="imageboardid" REFTABLE="unilabeltype_imageboard" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/imageboard/db/upgrade.php
+++ b/type/imageboard/db/upgrade.php
@@ -174,5 +174,17 @@ function xmldb_unilabeltype_imageboard_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024122600, 'unilabeltype', 'imageboard');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_imageboard');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        $table = new xmldb_table('unilabeltype_imageboard_img');
+        $key = new xmldb_key('imageboardid', XMLDB_KEY_FOREIGN, ['imageboardid'], 'unilabeltype_imageboard', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'imageboard');
+    }
+
     return true;
 }

--- a/type/imageboard/version.php
+++ b/type/imageboard/version.php
@@ -26,5 +26,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_imageboard';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;

--- a/type/topicteaser/db/install.xml
+++ b/type/topicteaser/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/unilabel/type/topicteaser/db" VERSION="20180729" COMMENT="XMLDB file for Moodle mod/unilabel/type/topicteaser"
+<XMLDB PATH="mod/unilabel/type/topicteaser/db" VERSION="20251012" COMMENT="XMLDB file for Moodle mod/unilabel/type/topicteaser"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
 >
@@ -20,6 +20,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="unilabelid" TYPE="foreign-unique" FIELDS="unilabelid" REFTABLE="unilabel" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/type/topicteaser/db/upgrade.php
+++ b/type/topicteaser/db/upgrade.php
@@ -124,5 +124,13 @@ function xmldb_unilabeltype_topicteaser_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020022900, 'unilabeltype', 'topicteaser');
     }
 
+    if ($oldversion < 2025101200) {
+        $table = new xmldb_table('unilabeltype_topicteaser');
+        $key = new xmldb_key('unilabelid', XMLDB_KEY_FOREIGN_UNIQUE, ['unilabelid'], 'unilabel', ['id']);
+        $dbman->add_key($table, $key);
+
+        upgrade_plugin_savepoint(true, 2025101200, 'unilabeltype', 'topicteaser');
+    }
+
     return true;
 }

--- a/type/topicteaser/version.php
+++ b/type/topicteaser/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'unilabeltype_topicteaser';
-$plugin->version   = 2025042210;
+$plugin->version   = 2025101200;
 $plugin->requires  = 2024100100;


### PR DESCRIPTION
Closes #73 

I was not 100% sure if the foreign keys from the unilabeltype tables, column `unilabelid`, to the table `unilabel`, column `id`, **are really unique**, but from my understanding of the unilabel architecture for each record in  `unilabeltype_TYPENAME` there is at most one in the table `unilabel`, correct?